### PR TITLE
GH-22: Seperate db for api_auth

### DIFF
--- a/api_auth/api_auth/app.py
+++ b/api_auth/api_auth/app.py
@@ -2,6 +2,7 @@
 from flask import Flask
 from webargs.flaskparser import parser, use_args
 
+from api_auth import const
 from api_auth.commands import register_commands
 from api_auth.extensions import api, register_extensions
 from api_auth.resources import CredentialSchema, register_resources
@@ -9,8 +10,8 @@ from api_auth.utils import JSONError, token_required
 
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'notverysecure'
-app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://postgres@database/postgres'
+app.config['SECRET_KEY'] = const.SECRET_KEY
+app.config['SQLALCHEMY_DATABASE_URI'] = const.DATABASE_URI
 
 
 @app.errorhandler(JSONError)

--- a/api_auth/api_auth/commands.py
+++ b/api_auth/api_auth/commands.py
@@ -1,7 +1,9 @@
 """Cli commands for api_auth."""
 import click
+from sqlalchemy_utils import create_database, database_exists
 
 from api_auth.extensions import db
+from api_auth import const
 
 
 def register_commands(app):
@@ -22,8 +24,10 @@ def register_commands(app):
 
     @app.cli.command()
     def initdb():
-        """Create all SQLAlchemy tables."""
-        db.create_all()
+        """Create the database and all SQLAlchemy tables if they do not exist."""
+        if not database_exists(const.DATABASE_URI):
+            create_database(const.DATABASE_URI)
+        db.create_all()  # create the tables
         click.echo('Created all tables')
 
     @app.cli.command()

--- a/api_auth/api_auth/const.py
+++ b/api_auth/api_auth/const.py
@@ -1,0 +1,4 @@
+"""Constants for api_auth."""
+
+DATABASE_URI = 'postgresql://postgres@database/auth'
+SECRET_KEY = 'notverysecure'

--- a/api_auth/api_auth/resources.py
+++ b/api_auth/api_auth/resources.py
@@ -2,13 +2,13 @@
 from datetime import datetime, timedelta
 
 import jwt
-from flask import current_app
 from flask.json import jsonify
 from flask_restful import Resource
 from marshmallow import (Schema, ValidationError, fields, validates,
                          validates_schema)
 from webargs.flaskparser import use_args
 
+from api_auth import const
 from api_auth.models import User
 
 
@@ -73,7 +73,7 @@ class TokenResourse(Resource):
 
         # Recall that encode returns a bytes object, so we will have to encode it
         # to be able to jsonify the token.
-        token_bytes = jwt.encode(content, current_app.config['SECRET_KEY'], algorithm='HS256')
+        token_bytes = jwt.encode(content, const.SECRET_KEY, algorithm='HS256')
         token = token_bytes.decode('UTF-8')
 
         return jsonify({

--- a/api_auth/api_auth/utils.py
+++ b/api_auth/api_auth/utils.py
@@ -2,9 +2,11 @@
 from functools import wraps
 
 import jwt
-from flask import current_app, jsonify, request
+from flask import jsonify, request
 from marshmallow import Schema, ValidationError, fields, validates
 from webargs.flaskparser import parser
+
+from api_auth import const
 
 
 class JSONError(Exception):
@@ -34,7 +36,7 @@ class ValidTokenSchema(Schema):
     def token_is_valid(self, value: str) -> None:
         """Return True iff the token is valid, otherwise raise a ValidationError."""
         try:
-            jwt.decode(value, current_app.config['SECRET_KEY'], algorithm='HS256')
+            jwt.decode(value, const.SECRET_KEY, algorithm='HS256')
         except jwt.exceptions.ExpiredSignatureError:
             raise ValidationError('Token is expired.')
         except jwt.exceptions.DecodeError:

--- a/api_auth/requirements.txt
+++ b/api_auth/requirements.txt
@@ -3,7 +3,8 @@ flask_restful
 flask-shell-ipython
 flask_sqlalchemy
 gnureadline
-psycopg2
 marshmallow
+psycopg2
 pyjwt
+sqlalchemy-utils
 webargs


### PR DESCRIPTION
This PR adds in a new const module for api_auth, service wide constants (better to use this than the app config) and also has api_auth using a seperate database (initdb now also creates the database if necessary).