### PR TITLE
GH-24: Better app config

### DIFF
--- a/api_auth/api_auth/app.py
+++ b/api_auth/api_auth/app.py
@@ -2,7 +2,6 @@
 from flask import Flask
 from webargs.flaskparser import parser, use_args
 
-from api_auth import const
 from api_auth.commands import register_commands
 from api_auth.extensions import api, register_extensions
 from api_auth.resources import CredentialSchema, register_resources
@@ -10,8 +9,8 @@ from api_auth.utils import JSONError, token_required
 
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = const.SECRET_KEY
-app.config['SQLALCHEMY_DATABASE_URI'] = const.DATABASE_URI
+app.config['SECRET_KEY'] = 'notverysecure'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://postgres@database/auth'
 
 
 @app.errorhandler(JSONError)

--- a/api_auth/api_auth/app.py
+++ b/api_auth/api_auth/app.py
@@ -1,4 +1,6 @@
 """The flask app and app configuration for api_auth."""
+from os import environ
+
 from flask import Flask
 from webargs.flaskparser import parser, use_args
 
@@ -8,25 +10,51 @@ from api_auth.resources import CredentialSchema, register_resources
 from api_auth.utils import JSONError, token_required
 
 
-app = Flask(__name__)
-app.config['SECRET_KEY'] = 'notverysecure'
-app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://postgres@database/auth'
-
-
-@app.errorhandler(JSONError)
-def handle_jsonerror(error):
-    """Return a jsonified response of a ValidationError's payload when it raised and uncaught."""
-    return error.get_response()
-
-
-@parser.error_handler
-def handle_error(error):
+def create_app():
     """
-    Handle webargs ValidationErrors by converting them to a JSONError.
+    Create a flask app for api_auth.
 
-    This will jsonify the payload.
+    Reads in two optional environment variables, FLASK_CONFIG_BASE AND FLASK_CONFIG_OVERRIDE.
+    FLASK_BASE_CONFIG specifies the base configuration to use, if nothing is given then it
+    defaults to api_auth/config/base.cfg.
+    FLASK_CONFIG_OVERRIDE provides overrides for the base config.
+    Note that you will probably have to provide one of these files since the SECRET_KEY must
+    be set and currently there is no secret key being set in the base config (this to ensure
+    that production does not use an insecure SECRET_KEY).
     """
-    raise JSONError(error.messages)
+    # pylint: disable=redefined-outer-name,unused-variable
+    app = Flask(__name__)
+
+    # Read in the base config (will read from '../cofnig/base.cfg' if FLASK_BASE_CONFIG isn't set
+    environ.setdefault('FLASK_BASE_CONFIG', '../config/base.cfg')
+    app.config.from_envvar('FLASK_BASE_CONFIG')
+
+    # Load in additional configuration overrides if FLASK_CONFIG_OVERRIDE is set
+    if 'FLASK_CONFIG_OVERRIDE' in environ:
+        app.config.from_envvar('FLASK_CONFIG_OVERRIDE')
+
+    @app.errorhandler(JSONError)
+    def handle_jsonerror(error):
+        """Return a jsonified response of an uncaught ValidationError's payload."""
+        return error.get_response()
+
+    @parser.error_handler
+    def handle_error(error):
+        """
+        Handle webargs ValidationErrors by converting them to a JSONError.
+
+        This will jsonify the payload.
+        """
+        raise JSONError(error.messages)
+
+    register_resources(api)
+    register_extensions(app)
+    register_commands(app)
+
+    return app
+
+
+app = create_app()
 
 
 @app.route('/foo-route')
@@ -35,12 +63,3 @@ def handle_error(error):
 def foo_route(data):
     """Test 'token-required' decorator."""
     return str(data)
-
-
-register_resources(api)
-register_extensions(app)
-register_commands(app)
-
-
-if __name__ == '__main__':
-    app.run(debug=True)

--- a/api_auth/api_auth/commands.py
+++ b/api_auth/api_auth/commands.py
@@ -3,7 +3,7 @@ import click
 from sqlalchemy_utils import create_database, database_exists
 
 from api_auth.extensions import db
-from api_auth import const
+from flask import current_app
 
 
 def register_commands(app):
@@ -25,8 +25,8 @@ def register_commands(app):
     @app.cli.command()
     def initdb():
         """Create the database and all SQLAlchemy tables if they do not exist."""
-        if not database_exists(const.DATABASE_URI):
-            create_database(const.DATABASE_URI)
+        if not database_exists(current_app.config['SQLALCHEMY_DATABASE_URI']):
+            create_database(current_app.config['SQLALCHEMY_DATABASE_URI'])
         db.create_all()  # create the tables
         click.echo('Created all tables')
 

--- a/api_auth/api_auth/const.py
+++ b/api_auth/api_auth/const.py
@@ -1,4 +1,0 @@
-"""Constants for api_auth."""
-
-DATABASE_URI = 'postgresql://postgres@database/auth'
-SECRET_KEY = 'notverysecure'

--- a/api_auth/api_auth/resources.py
+++ b/api_auth/api_auth/resources.py
@@ -2,13 +2,13 @@
 from datetime import datetime, timedelta
 
 import jwt
+from flask import current_app
 from flask.json import jsonify
 from flask_restful import Resource
 from marshmallow import (Schema, ValidationError, fields, validates,
                          validates_schema)
 from webargs.flaskparser import use_args
 
-from api_auth import const
 from api_auth.models import User
 
 
@@ -73,7 +73,7 @@ class TokenResourse(Resource):
 
         # Recall that encode returns a bytes object, so we will have to encode it
         # to be able to jsonify the token.
-        token_bytes = jwt.encode(content, const.SECRET_KEY, algorithm='HS256')
+        token_bytes = jwt.encode(content, current_app.config['SECRET_KEY'], algorithm='HS256')
         token = token_bytes.decode('UTF-8')
 
         return jsonify({

--- a/api_auth/api_auth/utils.py
+++ b/api_auth/api_auth/utils.py
@@ -2,11 +2,9 @@
 from functools import wraps
 
 import jwt
-from flask import jsonify, request
+from flask import jsonify, request, current_app
 from marshmallow import Schema, ValidationError, fields, validates
 from webargs.flaskparser import parser
-
-from api_auth import const
 
 
 class JSONError(Exception):
@@ -36,7 +34,7 @@ class ValidTokenSchema(Schema):
     def token_is_valid(self, value: str) -> None:
         """Return True iff the token is valid, otherwise raise a ValidationError."""
         try:
-            jwt.decode(value, const.SECRET_KEY, algorithm='HS256')
+            jwt.decode(value, current_app.config['SECRET_KEY'], algorithm='HS256')
         except jwt.exceptions.ExpiredSignatureError:
             raise ValidationError('Token is expired.')
         except jwt.exceptions.DecodeError:

--- a/api_auth/config/base.cfg
+++ b/api_auth/config/base.cfg
@@ -1,0 +1,1 @@
+SQLALCHEMY_DATABASE_URI = 'postgresql://postgres@database/auth'

--- a/api_auth/config/dev.cfg
+++ b/api_auth/config/dev.cfg
@@ -1,0 +1,1 @@
+SECRET_KEY = 'notverysecure'

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,6 +13,7 @@ services:
       - 5002:80
     environment:
       - FLASK_DEBUG=1
+      - FLASK_CONFIG_OVERRIDE=/app/api_auth/config/dev.cfg
 
   api-finances:
     command: 'flask run --host=0.0.0.0 --port=80'


### PR DESCRIPTION
The purpose of this PR is to improve how we are creating an configuring the flask app in api_auth.

Work done:
 * We are now using `current_app.config` instead of `const`
 * We are now using an app factory model to create our app
 * We now have external config files, a base config and different configs for different environments,
you can specify which override config file to use by setting the `FLASK_CONFIG_OVERRIDE` environment variable.

**Note**: We cannot set DEBUG in the config files since we are using flask run, no idea why but that's just the way it was (in my opinion -- badly) designed.