### PR TITLE
GH-12: Add tests for api_auth

### DIFF
--- a/api_auth/Dockerfile
+++ b/api_auth/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.3.6-wheezy
 
 EXPOSE 80
 
-ENV FLASK_APP "api_auth.app"
+ENV FLASK_APP "api_auth.wsgi"
 
 WORKDIR /app
 

--- a/api_auth/api_auth/app.py
+++ b/api_auth/api_auth/app.py
@@ -1,4 +1,4 @@
-"""The flask app and app configuration for api_auth."""
+"""The api_auth flask app factory."""
 from os import environ
 
 from flask import Flask

--- a/api_auth/api_auth/app.py
+++ b/api_auth/api_auth/app.py
@@ -4,13 +4,14 @@ from os import environ
 from flask import Flask
 from webargs.flaskparser import parser, use_args
 
+from api_auth import const
 from api_auth.commands import register_commands
 from api_auth.extensions import api, register_extensions
 from api_auth.resources import CredentialSchema, register_resources
 from api_auth.utils import JSONError, token_required
 
 
-def create_app():
+def create_app(config_override_file=None):
     """
     Create a flask app for api_auth.
 
@@ -26,12 +27,12 @@ def create_app():
     app = Flask(__name__)
 
     # Read in the base config (will read from '../cofnig/base.cfg' if FLASK_BASE_CONFIG isn't set
-    environ.setdefault('FLASK_BASE_CONFIG', '../config/base.cfg')
+    environ.setdefault('FLASK_BASE_CONFIG', const.CONFIG_DEFAULT_BASE)
     app.config.from_envvar('FLASK_BASE_CONFIG')
 
-    # Load in additional configuration overrides if FLASK_CONFIG_OVERRIDE is set
-    if 'FLASK_CONFIG_OVERRIDE' in environ:
-        app.config.from_envvar('FLASK_CONFIG_OVERRIDE')
+    # Load in additional configuration overrides if provided
+    if config_override_file is not None:
+        app.config.from_pyfile(config_override_file)
 
     @app.errorhandler(JSONError)
     def handle_jsonerror(error):
@@ -51,15 +52,11 @@ def create_app():
     register_extensions(app)
     register_commands(app)
 
+    @app.route('/foo-route')
+    @token_required
+    @use_args(CredentialSchema())
+    def foo_route(data):
+        """Test 'token-required' decorator."""
+        return str(data)
+
     return app
-
-
-app = create_app()
-
-
-@app.route('/foo-route')
-@token_required
-@use_args(CredentialSchema())
-def foo_route(data):
-    """Test 'token-required' decorator."""
-    return str(data)

--- a/api_auth/api_auth/const.py
+++ b/api_auth/api_auth/const.py
@@ -1,0 +1,4 @@
+"""Constant values for api_auth."""
+
+CONFIG_DEFAULT_BASE = '../config/base.cfg'
+CONFIG_TESTING = '../config/test.cfg'

--- a/api_auth/api_auth/tests/conftest.py
+++ b/api_auth/api_auth/tests/conftest.py
@@ -5,10 +5,12 @@ import pytest
 # pylint: disable=redefined-outer-name
 
 
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def app():
     """Return an instance of the flask app configured with test env variables."""
-    return auth_app.create_app(const.CONFIG_TESTING)
+    app = auth_app.create_app(const.CONFIG_TESTING)
+    with app.app_context():
+        yield app
 
 
 @pytest.fixture

--- a/api_auth/api_auth/tests/conftest.py
+++ b/api_auth/api_auth/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Common pytest fixtures that are automatically loaded for use."""
+from api_auth import app as auth_app, const
+import pytest
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture()
+def app():
+    """Return an instance of the flask app configured with test env variables."""
+    return auth_app.create_app(const.CONFIG_TESTING)
+
+
+@pytest.fixture
+def client(app):
+    """Return the testing client of the flask app."""
+    return app.test_client()

--- a/api_auth/api_auth/tests/test_resources.py
+++ b/api_auth/api_auth/tests/test_resources.py
@@ -1,0 +1,6 @@
+
+class TestFoo(object):
+
+    def test_foo(self, app, client):
+        assert True
+        import ipdb; ipdb.set_trace()

--- a/api_auth/api_auth/tests/test_resources.py
+++ b/api_auth/api_auth/tests/test_resources.py
@@ -1,6 +1,57 @@
+"""
+Tests for the resources in api_auth.resources.
 
-class TestFoo(object):
+Only the resources themselves are tested, schemas are not.
+"""
+import json
 
-    def test_foo(self, app, client):
-        assert True
-        import ipdb; ipdb.set_trace()
+import pytest
+
+from api_auth.extensions import db
+from api_auth.models import User
+
+
+class TestTokenResource:
+    """Test the Token resource."""
+
+    token_endpoint = '/token'
+
+    @pytest.mark.parametrize('uname', ['test_user', 'somthing_else', '', None])
+    @pytest.mark.parametrize('pword', ['password', '', None])
+    def test_get_token_with_invalid_credentials(self, client, uname, pword):
+        """Trying to get a token with invalid credentials fails."""
+        # Add a temporary user to the database
+        actual_username = 'test_user'
+        actual_password = 'myactualpassword'
+        user = User(username=actual_username, password=actual_password)
+        db.session.add(user)
+
+        # Attempt to get a token
+        req_data = {'username': uname, 'password': pword}
+        resp = client.get(self.token_endpoint, data=req_data)
+
+        # Check the response for a token
+        resp_data = json.loads(resp.data.decode('utf-8'))
+        assert 'token' not in resp_data.keys()
+
+        # Remove temporary user from database
+        db.session.rollback()
+
+    def test_get_token_with_valid_credentials(self, client):
+        """Trying to get a token with valid credentials succeeds."""
+        # Add a temporary user to the database
+        actual_username = 'test_user'
+        actual_password = 'myactualpassword'
+        user = User(username=actual_username, password=actual_password)
+        db.session.add(user)
+
+        # Attempt to get a token
+        req_data = {'username': actual_username, 'password': actual_password}
+        resp = client.get(self.token_endpoint, data=req_data)
+
+        # Check the response for a token
+        resp_data = json.loads(resp.data.decode('utf-8'))
+        assert 'token' in resp_data.keys()
+
+        # Remove temporary user from database
+        db.session.rollback()

--- a/api_auth/api_auth/wsgi.py
+++ b/api_auth/api_auth/wsgi.py
@@ -1,0 +1,16 @@
+"""
+Provides a way to run api_auth.
+
+Running with flask run requires that app be defined outside the `if`
+statment since it auto-discovers `app`.
+You can also start the app by simply runing this file via
+    `python /path/to/this/file/wsgi.py`
+"""
+from os import environ
+
+from api_auth.app import create_app
+
+app = create_app(environ['FLASK_CONFIG_OVERRIDE'])
+
+if __name__ == "__main__":
+    app.run()

--- a/api_auth/config/base.cfg
+++ b/api_auth/config/base.cfg
@@ -1,1 +1,2 @@
 SQLALCHEMY_DATABASE_URI = 'postgresql://postgres@database/auth'
+SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/api_auth/config/test.cfg
+++ b/api_auth/config/test.cfg
@@ -1,0 +1,2 @@
+SECRET_KEY = 'secretkeyfortesting'
+TESTING = True

--- a/api_auth/requirements.txt
+++ b/api_auth/requirements.txt
@@ -3,8 +3,10 @@ flask_restful
 flask-shell-ipython
 flask_sqlalchemy
 gnureadline
+ipdb
 marshmallow
 psycopg2
 pyjwt
+pytest
 sqlalchemy-utils
 webargs

--- a/toolchain/.pylintrc
+++ b/toolchain/.pylintrc
@@ -263,10 +263,10 @@ inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 # Naming hint for method names
-method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+method-name-hint=(([a-z][a-z0-9_]{2,50})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct method names
-method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+method-rgx=(([a-z][a-z0-9_]{2,50})|(_[a-z0-9_]*))$
 
 # Naming hint for module names
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$


### PR DESCRIPTION
The purpose of this PR is to add tests for api_auth.

The tests are by no means comprehensive, but they do cover the requirements, so for the time being anyways this should be good enough.

The app factory had to tweaked so that the app object wasn't defined in the same file as `create_app` (this prevents unintentional imports of the app object). Now when you create an app object, you can pass it a path to an override config file.

Also the annoying SQLAlchemy warning was suppressed, changes will now longer be automatically tracked.