### PR TITLE
GH-32: Use seperate db for testing

### DIFF
--- a/api_auth/api_auth/commands.py
+++ b/api_auth/api_auth/commands.py
@@ -1,7 +1,7 @@
 """Cli commands for api_auth."""
 import click
-from sqlalchemy_utils import create_database, database_exists
 
+from api_auth import utils
 from api_auth.extensions import db
 from flask import current_app
 
@@ -25,9 +25,7 @@ def register_commands(app):
     @app.cli.command()
     def initdb():
         """Create the database and all SQLAlchemy tables if they do not exist."""
-        if not database_exists(current_app.config['SQLALCHEMY_DATABASE_URI']):
-            create_database(current_app.config['SQLALCHEMY_DATABASE_URI'])
-        db.create_all()  # create the tables
+        utils.create_sqla_db(current_app, db)
         click.echo('Created all tables')
 
     @app.cli.command()

--- a/api_auth/api_auth/tests/conftest.py
+++ b/api_auth/api_auth/tests/conftest.py
@@ -1,5 +1,6 @@
 """Common pytest fixtures that are automatically loaded for use."""
-from api_auth import app as auth_app, const
+from api_auth import app as auth_app, const, utils
+from api_auth.extensions import db
 import pytest
 
 # pylint: disable=redefined-outer-name
@@ -10,6 +11,7 @@ def app():
     """Return an instance of the flask app configured with test env variables."""
     app = auth_app.create_app(const.CONFIG_TESTING)
     with app.app_context():
+        utils.create_sqla_db(app, db)
         yield app
 
 

--- a/api_auth/api_auth/utils.py
+++ b/api_auth/api_auth/utils.py
@@ -6,6 +6,8 @@ from flask import jsonify, request, current_app
 from marshmallow import Schema, ValidationError, fields, validates
 from webargs.flaskparser import parser
 
+from sqlalchemy_utils import create_database, database_exists
+
 
 class JSONError(Exception):
     """Represent errors that have a payload that should be a jsonified response."""
@@ -49,3 +51,10 @@ def token_required(func):
         parser.parse(ValidTokenSchema(), request)
         return func(*args, **kwargs)
     return test_for_valid_token
+
+
+def create_sqla_db(app, db) -> None:
+    """Create a database if it does not exist."""
+    if not database_exists(current_app.config['SQLALCHEMY_DATABASE_URI']):
+        create_database(current_app.config['SQLALCHEMY_DATABASE_URI'])
+    db.create_all()  # create the tables


### PR DESCRIPTION
This PR makes the tests for api_auth (currently the only tests being run) run in a separate database.